### PR TITLE
🚨 Fix hydration error in Rating component - Replace toLocaleString()

### DIFF
--- a/src/components/molecules/Rating.tsx
+++ b/src/components/molecules/Rating.tsx
@@ -14,6 +14,20 @@ interface RatingProps {
   'aria-label'?: string
 }
 
+/**
+ * Format numbers consistently for SSR/client compatibility
+ * Avoids toLocaleString() which causes hydration mismatches
+ */
+const formatCount = (count: number): string => {
+  if (count >= 1000000) {
+    return `${(count / 1000000).toFixed(1).replace(/\.0$/, '')}M`
+  }
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(1).replace(/\.0$/, '')}k`
+  }
+  return count.toString()
+}
+
 // Simple StarIcon component with style support
 const StarIcon: React.FC<{
   variant: 'filled' | 'outline'
@@ -122,7 +136,7 @@ export const Rating: React.FC<RatingProps> = ({
       className={`flex items-center gap-1 ${className}`}
       aria-label={
         ariaLabel ||
-        `${clampedValue} de ${max} estrelas${count ? ` (${count} avaliações)` : ''}`
+        `${clampedValue} de ${max} estrelas${count ? ` (${formatCount(count)} avaliações)` : ''}`
       }
       role="img"
     >
@@ -141,7 +155,7 @@ export const Rating: React.FC<RatingProps> = ({
 
       {showCount && count !== undefined && (
         <Text size={textSize} color="muted" className="ml-1">
-          ({count.toLocaleString()})
+          ({formatCount(count)})
         </Text>
       )}
     </div>


### PR DESCRIPTION
## 🚨 **Critical Bug Fix**
Fixes hydration error in Rating component causing SSR/client mismatch in Next.js 15.

## 🔍 **Problem**
```
Hydration failed because the server rendered text didn't match the client.
+ 1.429  (server)
- 1,429  (client)
```

**Root Cause:** `toLocaleString()` produces different outputs on server vs client due to locale differences.

## ✅ **Solution**

### **Before (Problematic):**
```typescript
({count.toLocaleString()}) // Inconsistent formatting
```

### **After (Fixed):**
```typescript
({formatCount(count)}) // Consistent formatting
```

### **New formatCount Utility:**
```typescript
const formatCount = (count: number): string => {
  if (count >= 1000000) return `${(count / 1000000).toFixed(1).replace(/\.0$/, '')}M`
  if (count >= 1000) return `${(count / 1000).toFixed(1).replace(/\.0$/, '')}k`
  return count.toString()
}
```

## 📊 **Examples**

| Input | Old Output (varies) | New Output (consistent) |
|-------|-------------------|------------------------|
| 429 | "429" | "429" |
| 1429 | "1,429" or "1.429" | "1.4k" |
| 1000 | "1,000" or "1.000" | "1k" |
| 1500000 | "1,500,000" or "1.500.000" | "1.5M" |

## 🧪 **Testing**
- ✅ **No hydration errors** in Next.js 15
- ✅ **Consistent rendering** server and client
- ✅ **Visual appeal maintained** with compact formatting
- ✅ **Performance improved** (no locale string operations)

## 📋 **Additional Benefits**
- **Better UX**: Compact numbers (1.4k vs 1,429)
- **Universal compatibility**: Works across all locales
- **Performance**: Faster than toLocaleString()
- **Predictable**: Same output regardless of environment

## 🔗 **Related Issue**
Closes #26

---
**🚨 HIGH PRIORITY** - This fix eliminates console errors and improves SSR stability!