### PR TITLE
feat: migrate tier 1 atoms to css variables

### DIFF
--- a/src/components/atoms/Input/Input.test.tsx
+++ b/src/components/atoms/Input/Input.test.tsx
@@ -97,7 +97,7 @@ describe('Input', () => {
     it('applies disabled styling', () => {
       render(<Input disabled />)
       expect(screen.getByRole('textbox')).toHaveClass(
-        'bg-gray-100',
+        'bg-[var(--color-gray-100,#f3f4f6)]',
         'cursor-not-allowed',
         'opacity-60'
       )
@@ -112,7 +112,7 @@ describe('Input', () => {
     it('applies readOnly styling', () => {
       render(<Input readOnly />)
       expect(screen.getByRole('textbox')).toHaveClass(
-        'bg-gray-100',
+        'bg-[var(--color-gray-100,#f3f4f6)]',
         'cursor-not-allowed',
         'opacity-60'
       )
@@ -121,16 +121,16 @@ describe('Input', () => {
     it('applies error styling', () => {
       render(<Input error />)
       expect(screen.getByRole('textbox')).toHaveClass(
-        'border-red-500',
-        'focus:ring-red-500'
+        'border-[var(--color-error-500,#ef4444)]',
+        'focus:ring-[var(--color-error-500,#ef4444)]'
       )
     })
 
     it('applies normal styling when not in error state', () => {
       render(<Input />)
       expect(screen.getByRole('textbox')).toHaveClass(
-        'border-gray-300',
-        'focus:ring-blue-500'
+        'border-[var(--color-gray-300,#d1d5db)]',
+        'focus:ring-[var(--color-primary-500,#3b82f6)]'
       )
     })
 

--- a/src/components/atoms/Input/Input.tsx
+++ b/src/components/atoms/Input/Input.tsx
@@ -75,13 +75,13 @@ export const Input = ({
 
   // 4. State classes (conditional)
   const stateClasses = error
-    ? 'border-red-500 focus:ring-red-500 focus:border-red-500'
-    : 'border-gray-300 focus:ring-blue-500 focus:border-blue-500'
+    ? 'border-[var(--color-error-500,#ef4444)] focus:ring-[var(--color-error-500,#ef4444)] focus:border-[var(--color-error-500,#ef4444)]'
+    : 'border-[var(--color-gray-300,#d1d5db)] focus:ring-[var(--color-primary-500,#3b82f6)] focus:border-[var(--color-primary-500,#3b82f6)]'
 
   const disabledClass =
     disabled || readOnly
-      ? 'bg-gray-100 cursor-not-allowed opacity-60'
-      : 'bg-white'
+      ? 'bg-[var(--color-gray-100,#f3f4f6)] cursor-not-allowed opacity-60'
+      : 'bg-[var(--color-background,#ffffff)]'
 
   // 5. Combine with template literal
   const classes = `${baseClasses} ${sizeClasses[size]} ${stateClasses} ${disabledClass} ${className}`
@@ -110,7 +110,10 @@ export const Input = ({
         }
       />
       {error && errorMessage && (
-        <p id={`${id}-error`} className="mt-1 text-sm text-red-600">
+        <p
+          id={`${id}-error`}
+          className="mt-1 text-sm text-[var(--color-error-600,#dc2626)]"
+        >
           {errorMessage}
         </p>
       )}

--- a/src/components/atoms/Link/Link.test.tsx
+++ b/src/components/atoms/Link/Link.test.tsx
@@ -15,7 +15,7 @@ describe('Link', () => {
     it('renders with default props', () => {
       render(<Link href="/test">Default Link</Link>)
       const link = screen.getByRole('link')
-      expect(link).toHaveClass('text-blue-600') // primary variant
+      expect(link).toHaveClass('text-[var(--color-primary-600,#2563eb)]') // primary variant
       expect(link).toHaveClass('underline')
       expect(link).toHaveAttribute('target', '_self')
     })
@@ -41,7 +41,7 @@ describe('Link', () => {
         </Link>
       )
       const link = screen.getByRole('link')
-      expect(link).toHaveClass('text-blue-600')
+      expect(link).toHaveClass('text-[var(--color-primary-600,#2563eb)]')
       expect(link).toHaveClass('underline')
     })
 
@@ -52,7 +52,7 @@ describe('Link', () => {
         </Link>
       )
       const link = screen.getByRole('link')
-      expect(link).toHaveClass('text-blue-600')
+      expect(link).toHaveClass('text-[var(--color-primary-600,#2563eb)]')
       expect(link).toHaveClass('no-underline')
     })
   })
@@ -266,7 +266,7 @@ describe('Link', () => {
       expect(link).toHaveClass('custom-class')
       // Should also have base classes
       expect(link).toHaveClass('transition-colors')
-      expect(link).toHaveClass('text-blue-600')
+      expect(link).toHaveClass('text-[var(--color-primary-600,#2563eb)]')
     })
 
     it('combines custom className with variant classes', () => {
@@ -278,7 +278,7 @@ describe('Link', () => {
       const link = screen.getByRole('link')
       expect(link).toHaveClass('font-bold')
       expect(link).toHaveClass('no-underline')
-      expect(link).toHaveClass('text-blue-600')
+      expect(link).toHaveClass('text-[var(--color-primary-600,#2563eb)]')
     })
   })
 

--- a/src/components/atoms/Link/Link.tsx
+++ b/src/components/atoms/Link/Link.tsx
@@ -22,12 +22,14 @@ export const Link = ({
 }: LinkProps) => {
   // Base classes
   const baseClasses =
-    'transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500'
+    'transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[var(--color-primary-500,#3b82f6)]'
 
   // Variant classes
   const variantClasses = {
-    primary: 'text-blue-600 hover:text-blue-800 underline',
-    secondary: 'text-blue-600 hover:text-blue-800 no-underline',
+    primary:
+      'text-[var(--color-primary-600,#2563eb)] hover:text-[var(--color-primary-800,#1e40af)] underline',
+    secondary:
+      'text-[var(--color-primary-600,#2563eb)] hover:text-[var(--color-primary-800,#1e40af)] no-underline',
   }
 
   // Auto-add security attributes for external links

--- a/src/components/atoms/Select/Select.stories.tsx
+++ b/src/components/atoms/Select/Select.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Select } from './Select'
+
+const defaultOptions = [
+  { value: 'opt1', label: 'Option 1' },
+  { value: 'opt2', label: 'Option 2' },
+  { value: 'opt3', label: 'Option 3' },
+]
+
+const meta = {
+  title: 'Design System/Atoms/Select',
+  component: Select,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+    },
+    disabled: {
+      control: 'boolean',
+    },
+    error: {
+      control: 'boolean',
+    },
+  },
+} satisfies Meta<typeof Select>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    options: defaultOptions,
+    placeholder: 'Select an option...',
+  },
+}
+
+export const WithError: Story = {
+  args: {
+    options: defaultOptions,
+    error: true,
+    errorMessage: 'This field is required',
+    id: 'error-select',
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    options: defaultOptions,
+    disabled: true,
+  },
+}
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3 w-64">
+      <Select options={defaultOptions} size="sm" placeholder="Small" />
+      <Select options={defaultOptions} size="md" placeholder="Medium" />
+      <Select options={defaultOptions} size="lg" placeholder="Large" />
+    </div>
+  ),
+}

--- a/src/components/atoms/Select/Select.test.tsx
+++ b/src/components/atoms/Select/Select.test.tsx
@@ -120,7 +120,7 @@ describe('Select', () => {
     it('applies error styling', () => {
       render(<Select options={mockOptions} error />)
       const select = screen.getByRole('combobox')
-      expect(select).toHaveClass('border-red-500')
+      expect(select).toHaveClass('border-[var(--color-error-500,#ef4444)]')
     })
 
     it('renders error message', () => {

--- a/src/components/atoms/Select/Select.tsx
+++ b/src/components/atoms/Select/Select.tsx
@@ -78,12 +78,12 @@ export const Select = ({
   }
 
   const stateClasses = error
-    ? 'border-red-500 focus:ring-red-500 focus:border-red-500'
-    : 'border-gray-300 focus:ring-blue-500 focus:border-blue-500'
+    ? 'border-[var(--color-error-500,#ef4444)] focus:ring-[var(--color-error-500,#ef4444)] focus:border-[var(--color-error-500,#ef4444)]'
+    : 'border-[var(--color-gray-300,#d1d5db)] focus:ring-[var(--color-primary-500,#3b82f6)] focus:border-[var(--color-primary-500,#3b82f6)]'
 
   const disabledClass = disabled
-    ? 'bg-gray-100 cursor-not-allowed opacity-60'
-    : 'bg-white'
+    ? 'bg-[var(--color-gray-100,#f3f4f6)] cursor-not-allowed opacity-60'
+    : 'bg-[var(--color-background,#ffffff)]'
 
   const classes = `${baseClasses} ${sizeClasses[size]} ${stateClasses} ${disabledClass} ${className}`
 
@@ -122,11 +122,14 @@ export const Select = ({
       </select>
       <ChevronDownIcon
         size={size === 'sm' ? 16 : size === 'lg' ? 24 : 20}
-        className={`absolute top-1/2 -translate-y-1/2 pointer-events-none text-gray-500 ${iconSizeClasses[size]}`}
+        className={`absolute top-1/2 -translate-y-1/2 pointer-events-none text-[var(--color-gray-500,#6b7280)] ${iconSizeClasses[size]}`}
         decorative
       />
       {error && errorMessage && (
-        <p id={`${id}-error`} className="mt-1 text-sm text-red-600">
+        <p
+          id={`${id}-error`}
+          className="mt-1 text-sm text-[var(--color-error-600,#dc2626)]"
+        >
           {errorMessage}
         </p>
       )}

--- a/src/components/atoms/Text/Text.test.tsx
+++ b/src/components/atoms/Text/Text.test.tsx
@@ -15,7 +15,7 @@ describe('Text', () => {
       const text = screen.getByText('Default Text')
       expect(text).toHaveClass('text-base')
       expect(text).toHaveClass('font-normal')
-      expect(text).toHaveClass('text-gray-900')
+      expect(text).toHaveClass('text-[var(--color-gray-900,#111827)]')
       expect(text.tagName).toBe('P')
     })
   })
@@ -70,22 +70,30 @@ describe('Text', () => {
   describe('Color Variants', () => {
     it('renders primary color (default)', () => {
       render(<Text color="primary">Primary</Text>)
-      expect(screen.getByText('Primary')).toHaveClass('text-gray-900')
+      expect(screen.getByText('Primary')).toHaveClass(
+        'text-[var(--color-gray-900,#111827)]'
+      )
     })
 
     it('renders secondary color', () => {
       render(<Text color="secondary">Secondary</Text>)
-      expect(screen.getByText('Secondary')).toHaveClass('text-gray-600')
+      expect(screen.getByText('Secondary')).toHaveClass(
+        'text-[var(--color-gray-600,#4b5563)]'
+      )
     })
 
     it('renders muted color', () => {
       render(<Text color="muted">Muted</Text>)
-      expect(screen.getByText('Muted')).toHaveClass('text-gray-500')
+      expect(screen.getByText('Muted')).toHaveClass(
+        'text-[var(--color-gray-500,#6b7280)]'
+      )
     })
 
     it('renders error color', () => {
       render(<Text color="error">Error</Text>)
-      expect(screen.getByText('Error')).toHaveClass('text-red-600')
+      expect(screen.getByText('Error')).toHaveClass(
+        'text-[var(--color-error-600,#dc2626)]'
+      )
     })
   })
 

--- a/src/components/atoms/Text/Text.tsx
+++ b/src/components/atoms/Text/Text.tsx
@@ -49,12 +49,12 @@ export const Text = ({
     extrabold: 'font-extrabold',
   }
   const colorClasses = {
-    primary: 'text-gray-900',
-    secondary: 'text-gray-600',
-    muted: 'text-gray-500',
-    success: 'text-green-600',
-    warning: 'text-yellow-600',
-    error: 'text-red-600',
+    primary: 'text-[var(--color-gray-900,#111827)]',
+    secondary: 'text-[var(--color-gray-600,#4b5563)]',
+    muted: 'text-[var(--color-gray-500,#6b7280)]',
+    success: 'text-[var(--color-success-600,#16a34a)]',
+    warning: 'text-[var(--color-warning-600,#d97706)]',
+    error: 'text-[var(--color-error-600,#dc2626)]',
   }
   const alignClasses = {
     left: 'text-left',

--- a/src/components/atoms/Textarea/Textarea.stories.tsx
+++ b/src/components/atoms/Textarea/Textarea.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Textarea } from './Textarea'
+
+const meta = {
+  title: 'Design System/Atoms/Textarea',
+  component: Textarea,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+    },
+    resize: {
+      control: 'select',
+      options: ['none', 'vertical', 'horizontal', 'both'],
+    },
+    disabled: {
+      control: 'boolean',
+    },
+    error: {
+      control: 'boolean',
+    },
+  },
+} satisfies Meta<typeof Textarea>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    placeholder: 'Enter your message...',
+  },
+}
+
+export const WithError: Story = {
+  args: {
+    placeholder: 'Enter your message...',
+    error: true,
+    errorMessage: 'This field is required',
+    id: 'error-textarea',
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    placeholder: 'Disabled textarea',
+    disabled: true,
+  },
+}
+
+export const WithCharCount: Story = {
+  args: {
+    placeholder: 'Type something...',
+    maxLength: 200,
+    showCharCount: true,
+  },
+}

--- a/src/components/atoms/Textarea/Textarea.test.tsx
+++ b/src/components/atoms/Textarea/Textarea.test.tsx
@@ -106,7 +106,7 @@ describe('Textarea', () => {
     it('applies error styling', () => {
       render(<Textarea error />)
       const textarea = screen.getByRole('textbox')
-      expect(textarea).toHaveClass('border-red-500')
+      expect(textarea).toHaveClass('border-[var(--color-error-500,#ef4444)]')
     })
 
     it('renders error message', () => {
@@ -210,7 +210,7 @@ describe('Textarea', () => {
       const textarea = screen.getByRole('textbox')
       fireEvent.change(textarea, { target: { value: '12345' } })
       const counter = screen.getByText('5/5')
-      expect(counter).toHaveClass('text-red-600')
+      expect(counter).toHaveClass('text-[var(--color-error-600,#dc2626)]')
     })
   })
 

--- a/src/components/atoms/Textarea/Textarea.tsx
+++ b/src/components/atoms/Textarea/Textarea.tsx
@@ -83,13 +83,13 @@ export const Textarea = ({
   }
 
   const stateClasses = error
-    ? 'border-red-500 focus:ring-red-500 focus:border-red-500'
-    : 'border-gray-300 focus:ring-blue-500 focus:border-blue-500'
+    ? 'border-[var(--color-error-500,#ef4444)] focus:ring-[var(--color-error-500,#ef4444)] focus:border-[var(--color-error-500,#ef4444)]'
+    : 'border-[var(--color-gray-300,#d1d5db)] focus:ring-[var(--color-primary-500,#3b82f6)] focus:border-[var(--color-primary-500,#3b82f6)]'
 
   const disabledClass =
     disabled || readOnly
-      ? 'bg-gray-100 cursor-not-allowed opacity-60'
-      : 'bg-white'
+      ? 'bg-[var(--color-gray-100,#f3f4f6)] cursor-not-allowed opacity-60'
+      : 'bg-[var(--color-background,#ffffff)]'
 
   const classes = `${baseClasses} ${sizeClasses[size]} ${resizeClasses[resize]} ${stateClasses} ${disabledClass} ${className}`
 
@@ -117,7 +117,10 @@ export const Textarea = ({
       />
       <div className="flex justify-between mt-1">
         {error && errorMessage ? (
-          <p id={`${id}-error`} className="text-sm text-red-600">
+          <p
+            id={`${id}-error`}
+            className="text-sm text-[var(--color-error-600,#dc2626)]"
+          >
             {errorMessage}
           </p>
         ) : (
@@ -125,7 +128,7 @@ export const Textarea = ({
         )}
         {showCharCount && maxLength && (
           <span
-            className={`text-sm ${charCount >= maxLength ? 'text-red-600' : 'text-gray-500'}`}
+            className={`text-sm ${charCount >= maxLength ? 'text-[var(--color-error-600,#dc2626)]' : 'text-[var(--color-gray-500,#6b7280)]'}`}
           >
             {charCount}/{maxLength}
           </span>


### PR DESCRIPTION
Migrates Text, Input, Textarea, Select, and Link to CSS variables with fallbacks for theme switching. Adds missing stories for Select and Textarea.